### PR TITLE
md5hex replaced with hash

### DIFF
--- a/src/somni/middleware/etag.clj
+++ b/src/somni/middleware/etag.clj
@@ -1,19 +1,13 @@
-(ns somni.middleware.etag
-  (:import (org.apache.commons.codec.digest DigestUtils)))
-
+(ns somni.middleware.etag)
 
 (defn- not-modified-response [etag]
   {:status 304 :headers {"Etag" etag}})
-
-(defn etag-generator [resp]
-  (DigestUtils/md5Hex (str (:body resp))))
 
 (defn- cached-response
   "Attach an etag header to response header. If old-etag and new-etag match then return a 304."
   [old-etag new-etag response]
   (if (= old-etag new-etag)
-    (not-modified-response new-etag)
-    (assoc-in response [:headers "Etag"] new-etag)))
+    (not-modified-response new-etag) response))
 
 (defn wrap-etag
   "Generates an etag header for a response body according to etag-generator
@@ -22,5 +16,5 @@
   (fn [request]
     (let [old-etag (get-in request [:headers "if-none-match"])
           response (handler request)
-          new-etag (etag-generator response)]
+          new-etag (get-in response [:headers "Etag"])]
       (cached-response old-etag new-etag response))))

--- a/src/somni/middleware/to_ring.clj
+++ b/src/somni/middleware/to_ring.clj
@@ -50,4 +50,5 @@
         (instance? Throwable resp) (throw resp)
 
         :else {:status (response-status request resp)
-               :body   resp}))))
+               :body   resp
+               :headers {"Etag" (str (hash resp))}}))))

--- a/test/somni/middleware/to_ring_test.clj
+++ b/test/somni/middleware/to_ring_test.clj
@@ -21,5 +21,5 @@
     (is (= (t-handler {})
            (t-handler {:request-method :get})
            (t-handler {:request-method :delete})
-           {:status 200 :body 't})
+           {:status 200 :body 't :headers {"Etag" (str (hash 't))}})
         "a handler that returns a non-nil value results in 200")))


### PR DESCRIPTION
Note : (hash resp) returns integer.Need to convert it to a str to compare with Etag in request-header